### PR TITLE
fix(gossamer): wire groove server + llm_coding command surface

### DIFF
--- a/src-gossamer/src/main.rs
+++ b/src-gossamer/src/main.rs
@@ -79,6 +79,18 @@ fn result_to_json<T: serde::Serialize>(result: Result<T, String>) -> Result<serd
     }
 }
 
+// Wrap a Result whose Ok variant is itself a JSON-encoded string,
+// so the response is `{"ok": true, "result": <object>}` instead of a
+// string-wrapped string the client would have to parse twice.
+fn result_str_to_json(result: Result<String, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(s) => result_to_json(Ok(
+            serde_json::from_str::<serde_json::Value>(&s).unwrap_or(serde_json::Value::Null),
+        )),
+        Err(e) => result_to_json::<serde_json::Value>(Err(e)),
+    }
+}
+
 fn blocking_get(url: &str, timeout_secs: u64) -> Result<String, String> {
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(timeout_secs))
@@ -123,6 +135,13 @@ fn blocking_post_empty(url: &str, timeout_secs: u64) -> Result<String, String> {
 // -----------------------------------------------------------------------
 
 fn main() {
+    // Spawn the groove discovery server (HTTP on 127.0.0.1:8000) on its own
+    // thread before the webview starts. This lets peers in the mesh
+    // (Burble, Vext, Hypatia, VeriSimDB) probe `/.well-known/groove` and
+    // discover PanLL's panel-ui capability for the entire app lifetime.
+    // `spawn()` also starts the mesh-monitor thread internally.
+    groove::spawn();
+
     // Initialize Gossamer app
     let app = App::new("PanLL", 1280, 800);
 
@@ -140,37 +159,66 @@ fn register_commands(app: &mut gossamer_rs::App) {
     // LLM Coding commands
     // -----------------------------------------------------------------------
 
-    // app.command("llm_coding_start", |payload| {
-    //     let session_id = get_str(&payload, "session_id").unwrap_or_default();
-    //     let prompt = get_str(&payload, "prompt").unwrap_or_default();
-    //     result_to_json(llm_coding::start_session(session_id, prompt))
-    // });
+    app.command("llm_coding_init", |_payload| {
+        result_str_to_json(llm_coding::commands::llm_coding_init())
+    });
 
-    // app.command("llm_coding_stop", |payload| {
-    //     let session_id = get_str(&payload, "session_id").unwrap_or_default();
-    //     result_to_json(llm_coding::stop_session(session_id))
-    // });
+    app.command("llm_coding_spawn", |payload: serde_json::Value| {
+        match serde_json::from_value::<llm_coding::types::SpawnRequest>(payload) {
+            Ok(request) => result_str_to_json(llm_coding::commands::llm_coding_spawn(request)),
+            Err(e) => result_to_json::<serde_json::Value>(Err(format!(
+                "Invalid SpawnRequest payload: {}",
+                e
+            ))),
+        }
+    });
 
-    // app.command("llm_coding_status", |payload| {
-    //     let session_id = get_str(&payload, "session_id").unwrap_or_default();
-    //     result_to_json(llm_coding::session_status(session_id))
-    // });
+    app.command("llm_coding_freeze", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_freeze(session_id))
+    });
 
-    // app.command("llm_coding_list", |_payload| {
-    //     result_to_json(llm_coding::list_sessions())
-    // });
+    app.command("llm_coding_thaw", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_thaw(session_id))
+    });
+
+    app.command("llm_coding_terminate", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_terminate(session_id))
+    });
+
+    app.command("llm_coding_list_sessions", |_payload| {
+        result_str_to_json(llm_coding::commands::llm_coding_list_sessions())
+    });
+
+    app.command("llm_coding_session_status", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_session_status(session_id))
+    });
+
+    app.command("llm_coding_append_message", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        let content = get_str(&payload, "content").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_append_message(
+            session_id, content,
+        ))
+    });
+
+    app.command("llm_coding_get_messages", |payload| {
+        let session_id = get_str(&payload, "session_id").unwrap_or_default();
+        result_str_to_json(llm_coding::commands::llm_coding_get_messages(session_id))
+    });
 
     // -----------------------------------------------------------------------
-    // Groove commands
+    // Groove discovery — no commands.
+    //
+    // Groove is an external discovery surface: peers probe
+    // `GET /.well-known/groove` on port 8000 to find PanLL's panel-ui
+    // capability. The server is launched in `main()` via `groove::spawn()`,
+    // which also starts the mesh monitor. There is nothing for the webview
+    // to call locally.
     // -----------------------------------------------------------------------
-
-    // app.command("groove_discover", |_payload| {
-    //     result_to_json(groove::discover())
-    // });
-
-    // app.command("groove_status", |_payload| {
-    //     result_to_json(groove::status())
-    // });
 
     // -----------------------------------------------------------------------
     // Service Registry commands (Connected Workbench v0.2.0)


### PR DESCRIPTION
## Summary

Closes #17 and closes #18 — both p1 issues asking to finish wiring the modules into the gossamer-rs `main.rs`. Both modules already had substantial implementations (~509 LOC `groove.rs`, ~518 LOC `llm_coding/`); what was missing was the wiring, and the pre-existing commented-out blocks were stale (from before the Tauri→gossamer-rs migration).

## What changed

`src-gossamer/src/main.rs`:

**Groove (#17)** — launched once at startup in `main()` via `groove::spawn()`, which also starts the mesh-monitor thread. Groove is an *external* discovery surface (peers probe `GET /.well-known/groove` on `127.0.0.1:8000`), not something the local webview should expose as Tauri-style commands. The misnamed `groove_discover`/`groove_status` shims were architecturally wrong and have been removed; replaced with a comment explaining where groove actually lives.

**LLM coding (#18)** — nine fresh `app.command(...)` registrations matching the real `llm_coding_*` API in `src-gossamer/src/llm_coding/commands.rs`:

| Command | Wraps |
| --- | --- |
| `llm_coding_init` | `llm_coding_init()` |
| `llm_coding_spawn` | `llm_coding_spawn(SpawnRequest)` |
| `llm_coding_freeze` | `llm_coding_freeze(session_id)` |
| `llm_coding_thaw` | `llm_coding_thaw(session_id)` |
| `llm_coding_terminate` | `llm_coding_terminate(session_id)` |
| `llm_coding_list_sessions` | `llm_coding_list_sessions()` |
| `llm_coding_session_status` | `llm_coding_session_status(session_id)` |
| `llm_coding_append_message` | `llm_coding_append_message(session_id, content)` |
| `llm_coding_get_messages` | `llm_coding_get_messages(session_id)` |

`llm_coding_spawn` deserialises a `SpawnRequest` struct via `serde_json::from_value` so typed payloads keep their shape.

**New helper** — `result_str_to_json` next to `result_to_json`. The `llm_coding_*` functions return `Result<String, String>` where the `String` is itself JSON; the helper parses the inner JSON before wrapping in `{"ok": true, "result": <object>}` so clients don't have to double-parse.

## Test plan

- [x] `cargo check` clean (15 pre-existing unused-function warnings in `settings.rs`, out of scope)
- [x] `cargo test --no-run` clean
- [x] `cargo test` — 0 tests in this binary (no test suite for `main.rs`); the modules' own tests are unaffected