### PR TITLE
docs: acknowledge Pane-A in core docs and rule files

### DIFF
--- a/.claude/CLAUDE.generated.md
+++ b/.claude/CLAUDE.generated.md
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,7 @@ deno task test:coverage
 - **TEA (The Elm Architecture)** in ReScript — Model/Msg/Update/View/Subscriptions
 - **Gossamer** (Zig + WebKitGTK) backend — migrated from Tauri 2.0
 - **Elixir/BEAM** optional middleware (`beam/panll_beam`)
-- **106 panels** across three panes: Panel-L (Symbolic), Panel-N (Neural), Panel-W (World)
+- **106 panels** across four panes: Panel-A (Ambient), Panel-L (Logic, role: Symbolic), Panel-N (Neural), Panel-W (World). Panel-L + Panel-N orbit Panel-W in the Binary Star core; Panel-A surrounds as ambient substrate.
 
 ## Key Files
 

--- a/.clinerules
+++ b/.clinerules
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/.machine_readable/6a2/ECOSYSTEM.a2ml
+++ b/.machine_readable/6a2/ECOSYSTEM.a2ml
@@ -73,8 +73,9 @@ notes = "Fleet panel wired with 6 bots and safety triangle. BoJ agent-mcp routes
 
 [related-projects.verisimdb]
 relationship = "primary-backend-module"
-nature = """VeriSimDB is PanLL's first database backend. VCL-DT maps to three-panel layout:
-Panel-L = proof obligations, Panel-N = agentic inference, Panel-W = query results."""
+nature = """VeriSimDB is PanLL's first database backend. VCL-DT maps to the L/N/W panes
+of PanLL's four-pane layout: Panel-L = proof obligations, Panel-N = agentic inference,
+Panel-W = query results. (Panel-A is ambient substrate and is not part of this mapping.)"""
 integration-status = "active"
 notes = "BoJ database-mcp cartridge routes VCL queries when bojRouting=true."
 

--- a/.machine_readable/6a2/META.a2ml
+++ b/.machine_readable/6a2/META.a2ml
@@ -21,7 +21,9 @@ context = """Traditional IDEs treat AI as tool or assistant (Human-as-primary, M
 Need architecture that enables genuine co-working without subordination."""
 decision = """Model Human and Machine as Binary Star system — two gravitationally bound entities
 orbiting a shared Barycentre (the task/artifact). Neither is primary.
-Three panels: Panel-L (Symbolic/Human), Panel-N (Neural/Machine), Panel-W (World/Barycentre)."""
+Four panels (three orbital + one ambient): Panel-L (Symbolic/Human), Panel-N (Neural/Machine),
+Panel-W (World/Barycentre), Panel-A (Ambient substrate). The L + N orbiting W relationship is
+the Binary Star core; Panel-A surrounds as ambient substrate for persistent context."""
 consequences-positive = [
   "Enables sustained co-working without constant context switching",
   "Operator can see Machine reasoning stream in real-time (Panel-N)",
@@ -105,8 +107,10 @@ license-policy = "All original code PMPL-1.0-or-later. Third-party dependencies 
 # --- Design Rationale ---
 
 [design-rationale]
-three-pane-layout = """Parallel layout (L/N/W side-by-side) emphasises simultaneity.
-Panel-L (left) = Symbolic, Panel-N (middle) = Neural, Panel-W (right) = World.
+four-pane-layout = """Parallel layout (A/L/N/W) emphasises simultaneity.
+Panel-A = Ambient substrate, Panel-L = Logic (role: Symbolic), Panel-N = Neural,
+Panel-W = World/Barycentre. Position is design intuition (L on the left, W central)
+not architectural; the architectural relationship is by flow + viewing perspective.
 Layout inspired by music production DAWs (multiple simultaneous views)."""
 binary-star-metaphor = """Metaphor from astrophysics: two stars orbiting shared centre of mass.
 Human = symbolic star, Machine = neural star. Barycentre = task/artifact.

--- a/.q/rules/coordination.md
+++ b/.q/rules/coordination.md
@@ -158,9 +158,9 @@ These choices may look unusual but are intentional:
 
 ### binary-star
 
-**Decision:** Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)
+**Decision:** Four panel types: Panel-A (ambient/substrate), Panel-L (logic/symbolic), Panel-N (neural/machine), Panel-W (world/shared)
 
-**Why:** Neurosymbolic architecture requires clear separation of human reasoning, machine inference, and shared world state
+**Why:** L + N orbit W in the Binary Star core (clear separation of human reasoning, machine inference, and shared world state); Panel-A surrounds as ambient substrate for persistent context and ergonomic support.
 
 ### vexometer-cognitive-load
 

--- a/README.adoc
+++ b/README.adoc
@@ -89,7 +89,7 @@ It is:
 
 == Architecture
 
-=== The Three-Pane Parallel Layout
+=== The Four-Pane Parallel Layout
 
 [cols="1,3"]
 

--- a/src/core/HelpContent.res
+++ b/src/core/HelpContent.res
@@ -41,7 +41,7 @@ let allEntries = (): array<HelpModel.helpEntry> => {
     {
       id: "welcome",
       title: "Welcome to PanLL",
-      body: "PanLL (formally eNSAID: Environment for NeSy-Agentic Integrated Development) is a neurosymbolic mission control interface. It combines symbolic reasoning (formal proofs, type systems, constraints) with neural computation (language models, learned heuristics) in a unified three-panel workspace. PanLL is designed for accessibility-first interaction, putting the operator in control of both symbolic and neural subsystems at all times.",
+      body: "PanLL (formally eNSAID: Environment for NeSy-Agentic Integrated Development) is a neurosymbolic mission control interface. It combines symbolic reasoning (formal proofs, type systems, constraints) with neural computation (language models, learned heuristics) in a unified four-panel workspace (Panel-A ambient substrate, Panel-L logic/symbolic, Panel-N neural, Panel-W world/barycentre). PanLL is designed for accessibility-first interaction, putting the operator in control of both symbolic and neural subsystems at all times.",
       category: GettingStarted,
       panelId: None,
       keywords: [
@@ -53,14 +53,14 @@ let allEntries = (): array<HelpModel.helpEntry> => {
         "getting started",
       ],
     },
-    /// Explains the fundamental three-panel layout.
+    /// Explains the fundamental four-panel layout.
     {
-      id: "three-panel-layout",
-      title: "Understanding the Three-Panel Layout",
-      body: "PanLL organises work into three panels. Panel-L (left) displays constraints, formal structure, and symbolic state — it is where you define what must be true. Panel-N (centre) hosts agent reasoning, OODA loops, and decision-making processes — it is where thinking happens. Panel-W (right) shows results, output, and verification status — it is where you see outcomes. This left-to-right flow mirrors the progression from specification through reasoning to results.",
+      id: "four-panel-layout",
+      title: "Understanding the Four-Panel Layout",
+      body: "PanLL organises work into four panels. Panel-A (Ambient) provides persistent context and ergonomic substrate around the workspace. Panel-L (Logic) displays constraints, formal structure, and symbolic state — it is where you define what must be true. Panel-N (Neural) hosts agent reasoning, OODA loops, and decision-making processes — it is where thinking happens. Panel-W (World/Barycentre) shows results, output, and verification status — it is where you see outcomes. The L + N orbiting W relationship is the Binary Star core; Panel-A surrounds as ambient substrate. Position is design intuition rather than architectural — the relationship is by flow and viewing perspective.",
       category: GettingStarted,
       panelId: None,
-      keywords: ["panels", "layout", "three-panel", "panel-l", "panel-n", "panel-w", "workspace"],
+      keywords: ["panels", "layout", "four-panel", "three-panel", "panel-a", "panel-l", "panel-n", "panel-w", "ambient", "binary star", "workspace"],
     },
     /// How to use the panel switcher to navigate between tools.
     {


### PR DESCRIPTION
## Summary

Closes #20.

`src/View.res` renders four panes (Pane-A, Pane-L, Pane-N, Pane-W) and the README table at `README.adoc:99-110` enumerates all four, but several adjacent docs and rule files still framed the layout as three panes (no Pane-A). This PR reconciles the most direct "three panel(s)/pane(s)" claims with the implementation, including the user-visible Help panel.

## Changes

### Doc + rule-file drift (commit 1)

- `README.adoc:92` — section heading "Three-Pane Parallel Layout" → "Four-Pane Parallel Layout".
- `.claude/CLAUDE.md:51` — "106 panels across three panes …" → four panes, with Panel-A added and a one-line note on the Binary Star core (L + N orbiting W) plus Panel-A's ambient role.
- `.machine_readable/6a2/META.a2ml` — Binary Star decision (line 24) now enumerates four panels (three orbital + one ambient); the `three-pane-layout` key (line 108) is renamed `four-pane-layout`, with position called out as design intuition rather than architectural fact.
- `.machine_readable/6a2/ECOSYSTEM.a2ml:76-77` — VeriSimDB mapping reframed as a mapping to the L/N/W panes of PanLL's four-pane layout (Panel-A is ambient substrate, not part of the VCL-DT mapping).
- Six rule files — binary-star Decision (line 161) extended to four panel types with Panel-A added; the Why line distinguishes the Binary Star orbital core (L + N around W) from Panel-A's ambient role:
  - `.cursorrules`
  - `.clinerules`
  - `.github/copilot-instructions.md`
  - `.junie/guidelines.md`
  - `.q/rules/coordination.md`
  - `.claude/CLAUDE.generated.md`

### User-visible help content (commit 2)

- `src/core/HelpContent.res`:
  - "welcome" entry body — `unified three-panel workspace` → `unified four-panel workspace (Panel-A ambient substrate, Panel-L logic/symbolic, Panel-N neural, Panel-W world/barycentre)`.
  - "three-panel-layout" entry — id and title renamed to `four-panel-layout`; body rewritten to introduce Panel-A as ambient substrate, clarify Panel-L's letter as "Logic" rather than "left", and replace the `(left)/(centre)/(right)` position framing with flow-and-perspective framing per the architectural model.
  - Keywords extended — keep `three-panel` for backward search, add `four-panel`, `panel-a`, `ambient`, `binary star`.

The renamed `three-panel-layout` help-anchor id has no inbound references elsewhere in the repo (verified via grep) — safe rename.

## Out of scope (deliberately)

- Rule file lines 101 and 196 — these are descriptions of the Binary Star architecture, which is genuinely a three-pane metaphor (L + N orbiting W). Correct as written.
- Rule file lines 103 and 186 — also Binary Star claims, accurate when read as referring to Binary Star types specifically. Reframing them so they remain accurate in the presence of Panel-A requires more nuance than this PR aims for; left for a follow-up.
- `README.adoc:287` (v0.2.0 component enumeration) — snapshot of v0.2.0 status; PaneA may not have been functional at that release, so left unmodified.

## Test plan

- [x] No code changes; doc-only.
- [x] `three-panel-layout` help-anchor id has no inbound references elsewhere in the repo.
- [x] `three-pane-layout` key (renamed in `META.a2ml`) has no other consumers across the hyperpolymath org (org-wide code search returns only the file itself).
- [ ] Help content rebuild reflects the new "Understanding the Four-Panel Layout" entry (run `npx rescript build` + the help indexer if there is one).