### PR TITLE
feat(schema): panll-harness/v2 binary_star architecture-declaration fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (2026-05-11 — Harness schema: Binary Star architecture declaration)
+- **`binary_star` object in panll-harness-v2 schema** — panels can now declare
+  their relationship to the Binary Star architecture (panes A/L/N/W) via
+  four optional fields:
+  - `spans` — panes the panel inhabits (primary state or computation)
+  - `flow` — ordered sequence describing data/control movement
+  - `surfaces_in` — panes where outputs become visible to other panels
+  - `perspective` — vantage point (canonical: observer, meta-observer, actor,
+    sensor, transformer)
+
+  Backward compatible: all fields optional, existing valid v2 manifests remain
+  valid. Unblocks `hyperpolymath/hypatia#197` and `hyperpolymath/hypatia#177`.
+
 ### Fixed (2024-04-15 — v0.2.0 Panic Attack Remediation)
 - **Critical Build Issues** — Resolved 37 compilation errors and warnings during panic attack:
   - Fixed `http_client` import syntax in `service_registry.rs`

--- a/schema/panll-harness-v2.schema.json
+++ b/schema/panll-harness-v2.schema.json
@@ -119,6 +119,43 @@
       "type": "string",
       "description": "Clade taxonomy path for topic-based event routing"
     },
+    "binary_star": {
+      "type": "object",
+      "description": "Declares this panel's relationship to the Binary Star architecture. Panels do not belong to a single pane — they span, flow between, and surface in panes by role. Pane letters: A (Ambient), L (Logic / symbolic), N (Neural), W (World).",
+      "properties": {
+        "spans": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["A", "L", "N", "W"]
+          },
+          "uniqueItems": true,
+          "description": "Panes this panel inhabits (i.e. holds primary state or computation in). A panel may span multiple panes; e.g. a meta-observer that holds both a rules engine (L) and neural models (N) declares spans = [\"L\", \"N\"]."
+        },
+        "flow": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["A", "L", "N", "W"]
+          },
+          "description": "Ordered sequence of pane letters describing how data or control moves through the panel's pipeline. Order matters; repeats are allowed (a loop returning to L is flow = [\"L\", \"N\", \"L\"])."
+        },
+        "surfaces_in": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["A", "L", "N", "W"]
+          },
+          "uniqueItems": true,
+          "description": "Panes where this panel's outputs (findings, dispatches, view updates) become visible to other panels. Typically a subset of, or disjoint from, spans — e.g. a panel that spans [L, N] may surface its dispatches in W."
+        },
+        "perspective": {
+          "type": "string",
+          "description": "Vantage point or role within the Binary Star architecture. Canonical values: \"observer\" (reads/displays state), \"meta-observer\" (observes other panels' state), \"actor\" (takes actions on the world), \"sensor\" (raw data ingestion), \"transformer\" (converts data between panes). Other values permitted but should be added to this enum over time."
+        }
+      },
+      "additionalProperties": false
+    },
     "integrations": {
       "type": "object",
       "description": "Connections to other PanLL services",


### PR DESCRIPTION
## Summary

Panels relate to the Binary Star architecture (panes A/L/N/W) by **flow** and **viewing perspective**, not single-pane membership. The v2 schema had no fields to express this, blocking downstream consumers (`hypatia#197`, `hypatia#177`).

Adds an optional `binary_star` object to `panll-harness/v2`:

```toml
[binary_star]
spans = ["L", "N"]                  # panes the panel inhabits
flow = ["L", "N", "W"]              # ordered data/control movement
surfaces_in = ["W"]                 # where outputs become visible
perspective = "meta-observer"       # vantage point
```

Pane letters constrained to enum `[A, L, N, W]`. `perspective` is a free string with documented canonical values (`observer`, `meta-observer`, `actor`, `sensor`, `transformer`).

**Backward compatible** — all fields optional; existing valid v2 manifests remain valid. Schema `$id` and `$schema` const unchanged.

## Unblocks
- `hyperpolymath/hypatia#197` — declare Hypatia panel's flow/perspective
- `hyperpolymath/hypatia#177` (parent design discussion, per #197 reference)

## Test plan
- [x] JSON schema validates as well-formed (`python -c "import json; json.load(...)"`)
- [ ] Run any panll schema validation tests in CI
- [ ] After merge, hypatia harness PR can land its `[binary_star]` declaration