### PR TITLE
ci(secret-scanner): drop duplicate --fail from trufflehog extra_args

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -21,7 +21,7 @@ jobs:
       - name: TruffleHog Secret Scan
         uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
         with:
-          extra_args: --only-verified --fail
+          extra_args: --only-verified
 
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The trufflehog GitHub Action passes `--fail` automatically. Passing it again via `extra_args` causes:

```
trufflehog: error: flag 'fail' cannot be repeated
```

This unblocks the trufflehog gate.

Same fix as hyperpolymath/hypatia#227 and hyperpolymath/boj-server#59.