### PR TITLE
fix(ci): pin upload-artifact to valid SHA in hypatia-scan.yml (Refs standards#48)

### DIFF
--- a/panel-clades/.github/workflows/hypatia-scan.yml
+++ b/panel-clades/.github/workflows/hypatia-scan.yml
@@ -74,7 +74,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json


### PR DESCRIPTION
Generator-materialized `hypatia-scan.yml` pinned `actions/upload-artifact@v4` to nonexistent SHA `65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478`; corrected to `ea165f8d65b6e75b540449e92b4886f43607fa02`. Generator already fixed (gitbot-fleet#163). 1 file(s).

Refs standards#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)