### PR TITLE
fix(affine): migrate record literals to #{ } (affinescript#218)

### DIFF
--- a/src/ui/tea/panll_gui.affine
+++ b/src/ui/tea/panll_gui.affine
@@ -41,7 +41,7 @@ enum Msg {
  * Initial state: PaneW (Task Barycentre) with no history.
  */
 fn panll_init() -> Model {
-  {
+  #{
     current_pane: PanLLPane::PaneW,
     history_depth: 0
   }
@@ -58,7 +58,7 @@ fn panll_update(@linear msg: Msg, @linear model: Model) -> Model {
       match msg {
         Navigate(new_pane) => {
           // Consume old model, produce new model with incremented history depth
-          { 
+          #{
             current_pane: new_pane, 
             history_depth: h + 1 
           }
@@ -67,13 +67,13 @@ fn panll_update(@linear msg: Msg, @linear model: Model) -> Model {
         PopState => {
           if h > 0 {
             // Return to PaneW if stack has items
-            { 
+            #{
               current_pane: PanLLPane::PaneW, 
               history_depth: h - 1 
             }
           } else {
             // No-op transition: return model as-is
-            { 
+            #{
               current_pane: c, 
               history_depth: 0 
             }


### PR DESCRIPTION
AffineScript #218 (merged) made bare `{` a block; records use `#{ }`. Migrated the 4 expression-position record literals in `src/ui/tea/panll_gui.affine` (init return + 3 update match-arm Model values). Patterns/blocks unchanged. Verified parses clean under the new affinescript compiler.

Refs hyperpolymath/affinescript#218