### PR TITLE
fix(licence): #3 Tranche 1 — clear scaffold-placeholder leak (panll)

### DIFF
--- a/panel-clades/.machine_readable/contractiles/trust/Trustfile.a2ml
+++ b/panel-clades/.machine_readable/contractiles/trust/Trustfile.a2ml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMLP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # =============================================================================
 # A2ML Trustfile Template (Cyber-Resilient Baseline)
 # Replace all {{PLACEHOLDERS}} for each derived repository.


### PR DESCRIPTION
#3 Tranche 1 (post-pilot #32-shape). Scaffold-placeholder leak per `standards/LICENCE-POLICY.adoc` **A5** — NOT relicensing. PLMP/PMLP + doubled-suffix substituted to this repo's correct id `PMPL-1.0-or-later`. **1 file(s).** Gates: diff-shape asserted (SPDX-only, auto-revert on anomaly), zero residual, no 3c file. 🤖 Generated with [Claude Code](https://claude.com/claude-code)