### PR TITLE
ci(gitignore): ignore generated/* artefacts (Refs standards#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,14 @@ _build/
 deps/
 .elixir_ls/
 .cache/
+
+# generated/* — produced by boj-server -mcp cartridges on push via *-regen.yml.
+# DO NOT commit these. If missing locally, trigger regeneration:
+#   curl -X POST http://boj-server.local:7700/cartridges/k9iser-mcp/invoke \
+#     -d '{"repo": "hyperpolymath/<repo>", "tool": "k9_generate"}'
+# Standards#93 / #89 sub-issue 1+2 must be wired before this line is safe.
+generated/k9iser/
+generated/tlaiser/
+generated/wokelangiser/
+generated/alloyiser/
+generated/abi/


### PR DESCRIPTION
## Summary

- Apply the prepared `.gitignore` stanza from standards#93 so future regenerated `generated/*` outputs aren't committed.
- Existing tracked files are intentionally NOT removed — that waits on standards#91 Phase E (production-wired regen gateway, ~8-12 wk).

## Refs

- hyperpolymath/standards#93 — Stop committing generated/*

## Test plan

- [x] `.gitignore` patches cleanly; no tracked files touched
- [x] `git status` after change shows no spurious diffs (existing tracked `generated/*` files remain tracked)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)