### PR TITLE
fix(deps): bump openssl 0.10.78 -> 0.10.80 (closes 3 Dependabot alerts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,15 +861,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -893,9 +892,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Three open Dependabot alerts on `main` (1 high, 2 moderate) all pointed at the transitive `openssl` crate pulled in via `reqwest = "0.12"`. Bumping to 0.10.80 (the highest patched-version requirement) closes all three at once.

| Alert | Severity | Patched in |
| --- | --- | --- |
| #12 — `X509Ref::ocsp_responders` UB on non-UTF-8 OCSP URLs | **HIGH** | 0.10.79 |
| #13 — rust-openssl heap buffer overflow on AES key-wrap-with-padding encryption | medium | 0.10.79 |
| #14 — Potential OOB write in `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers | medium | 0.10.80 |

Lockfile-only change — no `Cargo.toml` touched, no behaviour change in panll. `openssl-sys` is dragged from 0.9.114 → 0.9.116 as required by the openssl bump.

## Test plan

- [x] `cargo update -p openssl --precise 0.10.80` produces only openssl + openssl-sys version bumps in the lockfile
- [ ] CI green on this PR
- [ ] Post-merge: Dependabot auto-dismisses alerts #12, #13, #14 on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)