### PR TITLE
audit: classify 6 FFI/systems unsafe findings as legitimate (PA001/PA007)

### DIFF
--- a/audits/assail-classifications.a2ml
+++ b/audits/assail-classifications.a2ml
@@ -1,0 +1,51 @@
+;; SPDX-License-Identifier: MPL-2.0
+;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+;;
+;; Assail Classifications — panll
+;; See panic-attack/.claude/CLAUDE.md § "User-Classification Registry".
+
+(assail-classifications
+  (metadata
+    (version "1.0.0")
+    (project "panll")
+    (last-updated "2026-05-26")
+    (entries 6)
+    (status "active"))
+
+  (classification
+    (file "ffi/zig/src/coprocessor.zig")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+  (classification
+    (file "src-gossamer/src/coprocessor/commands.rs")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+  (classification
+    (file "src-gossamer/src/coprocessor/commands.rs")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+  (classification
+    (file "src-gossamer/src/system_tray/mod.rs")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+  (classification
+    (file "src-gossamer/src/workspace/sysinfo.rs")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+  (classification
+    (file "src-gossamer/src/llm_coding/commands.rs")
+    (category "UnsafeCode")
+    (classification "legitimate-ffi")
+    (audit "audits/audit-ffi-2026-05-26.md")
+    (rationale "panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary."))
+)

--- a/audits/audit-ffi-2026-05-26.md
+++ b/audits/audit-ffi-2026-05-26.md
@@ -1,0 +1,28 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+-->
+
+# Audit: FFI / systems `unsafe` blocks (panll)
+
+**Auditor**: Jonathan D.A. Jewell
+**Date**: 2026-05-26
+**Scope**: panic-attack assail Critical/High `UnsafeCode` (PA001) and `UnsafeFFI` (PA007) findings located under: `ffi/zig/src/, src-gossamer/src/`.
+**Cross-reference**: campaign tracker [hyperpolymath/panic-attack#32](https://github.com/hyperpolymath/picpath/issues/32).
+**Registry**: `audits/assail-classifications.a2ml`.
+
+## Rationale
+
+panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary.
+
+The classification is scoped to the listed root(s). Any `unsafe` block outside those roots remains visible to assail.
+
+## Anti-gameability
+
+The registry is a separate file from any source under scan; adding a new `unsafe` block inside a classified root requires a companion classification edit and an update to this audit doc, both of which are visible in the diff.
+
+## Verification
+
+Locally on this branch: `panic-attack assail . --headless` reports the listed PA001/PA007 findings as `suppressed: true`. Any new `unsafe` outside the listed roots remains unsuppressed.
+
+Refs hyperpolymath/panic-attack#32.


### PR DESCRIPTION
## Summary

`panic-attack assail` reports **6** `UnsafeCode` (PA001) + `UnsafeFFI` (PA007) Critical/High findings under `ffi/zig/src/, src-gossamer/src/` in this repo. All sit at the C-ABI / syscall / kernel boundary and are required by the host language to call across.

Rationale: panll is a panel-clades language with a Tauri-style desktop wrapper. ffi/zig/src is the Zig FFI bridge to the Idris2 core; src-gossamer/src is the (frozen, see ADR-0001) Rust desktop shell using OS-FFI for system_tray destroy, sysinfo workspace probing, and coprocessor/llm_coding command pipes. All unsafe at the C-ABI / OS-FFI boundary.

## What changes

- `audits/assail-classifications.a2ml` — 6 entries, `classification=legitimate-ffi`.
- `audits/audit-ffi-2026-05-26.md` — auditor record + anti-gameability note.

## Scope

Classification is **scoped to the listed roots** (ffi/zig/src/, src-gossamer/src/). Any unsafe block outside those roots remains visible.

## Anti-gameability

Same pattern as `hyperpolymath/svalinn`, `hyperpolymath/proven`, `hyperpolymath/gossamer`, `hyperpolymath/docudactyl`, `hyperpolymath/proven-servers`, `hyperpolymath/aerie`, and `hyperpolymath/boj-server` — registry is a separate file from any source under scan; new unsafe in a classified root requires a companion classification edit + audit-doc update, both visible.

## Verification

Locally: `panic-attack assail . --headless` reports the 6 findings as `suppressed: true` on this branch.

Refs hyperpolymath/panic-attack#32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)