### PR TITLE
chore(licence): migrate Cargo.toml + package.json from PMPL-1.0-or-later to MPL-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 #
 # PanLL eNSAID — Gossamer backend
 #
@@ -17,7 +17,7 @@ version = "0.2.0"
 description = "PanLL eNSAID - Environment for NeSy-Agentic Integrated Development (Gossamer backend)"
 authors = ["Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>"]
 edition = "2021"
-license = "PMPL-1.0-or-later"
+license = "MPL-2.0"
 repository = "https://github.com/hyperpolymath/panll"
 
 # Testable logic library — GTK/WebKit-free. `cargo test --lib` runs without

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gossamer"
   ],
   "author": "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
-  "license": "PMPL-1.0-or-later",
+  "license": "MPL-2.0",
   "dependencies": {
     "@rescript/runtime": "^12.2.0"
   }


### PR DESCRIPTION
## Summary
- Updates both `Cargo.toml` and `package.json` license fields from `PMPL-1.0-or-later` to `MPL-2.0`.
- Closes the SPDX-vs-manifest mismatch flagged by standards#196.

## Companion
- standards#196 — licence debt audit
- standards#201 — licence-consistency CI check

🤖 Generated with [Claude Code](https://claude.com/claude-code)