### PR TITLE
docs(claude-md): note ReScript→AffineScript migration trajectory

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ deno task test:coverage
 
 ## Architecture
 
-- **TEA (The Elm Architecture)** in ReScript — Model/Msg/Update/View/Subscriptions
+- **TEA (The Elm Architecture)** in ReScript (migrating to AffineScript per `hyperpolymath/standards#252`) — Model/Msg/Update/View/Subscriptions
 - **Gossamer** (Zig + WebKitGTK) backend — migrated from Tauri 2.0
 - **Elixir/BEAM** optional middleware (`beam/panll_beam`)
 - **106 panels** across four panes: Panel-A (Ambient), Panel-L (Logic, role: Symbolic), Panel-N (Neural), Panel-W (World). Panel-L + Panel-N orbit Panel-W in the Binary Star core; Panel-A surrounds as ambient substrate.
@@ -71,14 +71,16 @@ deno task test:coverage
 ## Critical Rules
 
 - **NEVER use Tauri** — project migrated to Gossamer. All backend refs use `src-gossamer/`
-- **NEVER use TypeScript** — ReScript only
-- **NEVER use npm/bun** — Deno only (npm used only for ReScript compiler)
+- **NEVER use TypeScript** — current source is ReScript; **new modules MUST be AffineScript** per `hyperpolymath/standards#252` (ReScript→AffineScript estate umbrella). Don't introduce new `.res`/`.resi` files in new feature work.
+- **NEVER use npm/bun** — Deno only (npm used only for the legacy ReScript compiler invocation; estate target is `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0` per `hyperpolymath/standards#253`)
 - **Panels, not panes** — PanLL uses "panels" terminology
 - **TEA pattern only** — no MVC, no Redux, no hooks. Model -> Msg -> Update -> View
 - **All state in Model.model** — no global mutable state
 - **Anti-Crash validates ALL neural tokens** — no inference bypasses the circuit breaker
 
-## ReScript Conventions
+## ReScript Conventions (legacy — apply when touching existing `.res`/`.resi`)
+
+> New modules should be AffineScript per `hyperpolymath/standards#252`. These conventions remain authoritative for edits to the existing ReScript surface until migration completes.
 
 - Use `list{}` for vdom children: `Tea_Html.div(list{}, list{...})`
 - Use `Events.onClick` / `Events.onInput` for event handlers


### PR DESCRIPTION
## Summary

`panll/.claude/CLAUDE.md` previously said "NEVER use TypeScript — ReScript only" with no acknowledgement of the 2026-05-25 estate language policy. panll is ReScript-heavy (TEA in `.res`, ~7500-line `Update.res`), so this PR does **not** wholesale flip — it adds a migration-trajectory note so future Claude sessions know:

- AffineScript is the target for **new** modules per [`hyperpolymath/standards#252`](https://github.com/hyperpolymath/standards/issues/252)
- Don't add new `.res`/`.resi` files outside the existing surface
- The `npm:rescript` invocation is legacy (Deno-native command at [`hyperpolymath/standards#253`](https://github.com/hyperpolymath/standards/issues/253))

Existing **ReScript Conventions** section preserved unchanged (still authoritative for edits to the existing `.res` surface) but section header marked `(legacy)`.

## Changes

- Architecture line: `TEA in ReScript` → `TEA in ReScript (migrating to AffineScript per standards#252)`
- Critical Rules: TS rule augmented with "new modules MUST be AffineScript"; npm/bun rule notes legacy-rescript invocation
- ReScript Conventions section header marked legacy + lead paragraph explaining trajectory

## Why not a wholesale flip?

Per `hyperpolymath/standards#281` discussion and the other repos in this sweep (phronesis / dotfiles / developer-ecosystem flipped tables wholesale), panll's reality requires a softer touch — the docs must reflect what code-in-the-repo actually is while pointing at the target. Honest documentation > aspirational.

## Test plan

- [x] No code changes — docs-only PR
- [x] GPG-signed
- [x] Existing ReScript build/dev commands preserved (still accurate)

Refs: hyperpolymath/standards#239
Refs: hyperpolymath/standards#252
Refs: hyperpolymath/standards#281