### PR TITLE
fix(ci): replace fake denoland/setup-deno SHA pin (3 sites)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Deno
-        uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282  # v2.0.4
         with:
           deno-version: v2.x
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Deno
-        uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282  # v2.0.4
         with:
           deno-version: v2.x
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Deno
-        uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282  # v2.0.4
         with:
           deno-version: v2.x
 


### PR DESCRIPTION
## Summary

The pin `denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497` at `.github/workflows/e2e.yml:44,67,90` is fabricated. `gh api repos/denoland/setup-deno/commits/5fae568... → 422 "No commit found for SHA"`.

All three jobs (`e2e`, `crosscutting`, `benchmarks`) would have failed at action resolution on next run.

Replaced with verified v2.0.4 pin `667a34cdef165d8d2b2e98dde39547c9daac7282`.

## Provenance

- Propagated from `rsr-template-repo`'s `e2e.yml` template (commented stub uncommented when concretising here)
- Template fixed upstream: hyperpolymath/rsr-template-repo#81 (merged)
- Discovered while wiring CI for snifs: hyperpolymath/snifs#30
- Companion to: `reposystem` (incoming), `odds-and-sods-package-manager#39`, `proven#93` (merged), `proven-servers#19`

## Test plan

- [ ] All 3 setup-deno lines use `667a34cd...` (v2.0.4)
- [ ] `gh api repos/denoland/setup-deno/commits/667a34cdef165d8d2b2e98dde39547c9daac7282` returns 200
- [ ] E2E / crosscutting / benchmarks jobs resolve their setup step instead of 422'ing