### PR TITLE
fix(ci): swap npm run res:build → npx rescript build (no scripts entry)

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -41,7 +41,16 @@ jobs:
             patchelf
 
       - name: Install npm dependencies
-        run: npm ci
+        # `npm ci` requires package-lock.json to be a complete resolution
+        # of package.json. The committed lockfile is incomplete: tailwindcss's
+        # nested deps (chokidar wants picomatch@^2.3.1 at the top level)
+        # are missing entries, so `npm ci` refuses with "Missing: picomatch@2.3.2
+        # from lock file". `npm install` is non-strict and regenerates the
+        # missing entries in-place during CI, unblocking the gate without
+        # committing a touched lockfile. The real fix is the npm→Deno
+        # migration tracked in hyperpolymath/standards#253; this is a
+        # band-aid to keep CI green until then.
+        run: npm install --no-audit --no-fund
 
       - name: ReScript build gate
         run: npm run res:build

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm install --no-audit --no-fund
 
       - name: ReScript build gate
-        run: npm run res:build
+        run: npx --no-install rescript build
 
       - name: Deno test gate
         run: deno task test


### PR DESCRIPTION
## Summary

`.github/workflows/build-validation.yml` line 56 invoked `npm run res:build` but `package.json` has no `scripts` entry. The project's canonical ReScript invocation per `.claude/CLAUDE.md` is `npx rescript build` directly. Using the canonical form unblocks the `validate` required check across every PR without polluting `package.json` with a stub script alias.

This was blocking #62 (the lockfile-drift CI fix) and every subsequent PR's `validate` job.

## Test plan

- [ ] `validate` job goes green on this PR
- [ ] Re-arms / clears the back-pressure on #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)