### PR TITLE
docs: post-#65 sweep — remove stale npx/npm/Tauri prose

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -70,7 +70,7 @@ or contradict deliberate architectural decisions.
 
 **Rule:** No npm, Bun, pnpm, or yarn — Deno is the orchestrator
 
-**Why:** npm is used ONLY for the ReScript compiler (which requires it). All other tooling uses Deno. Do not add npm dependencies.
+**Why:** Deno-only build (post panll#65). ReScript and Tailwind run via `npm:` specifiers in `deno.json` — there is no `package.json` and no npm CLI is invoked. Do not reintroduce npm/bun/yarn/pnpm tooling.
 
 ### [CRITICAL] anticrash-validates-all
 
@@ -150,11 +150,11 @@ These choices may look unusual but are intentional:
 
 **Rejected alternatives:** rescript-tea, Redux, MobX, React hooks pattern
 
-### deno-npm-hybrid
+### deno-only-with-npm-specifiers
 
-**Decision:** Deno orchestrates everything, but npm is used solely for the ReScript compiler
+**Decision:** Deno orchestrates everything; ReScript and Tailwind run via `npm:` specifiers in `deno.json`
 
-**Why:** ReScript compiler requires npm — this is the ONLY permitted npm usage. Do not extend npm's role.
+**Why:** Post panll#65: `package.json` + `package-lock.json` deleted; ReScript compiles via `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0 build`, Tailwind via `deno run -A npm:tailwindcss`. No npm CLI invocation. Do not extend npm's role.
 
 ### binary-star
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ or contradict deliberate architectural decisions.
 
 **Rule:** No npm, Bun, pnpm, or yarn — Deno is the orchestrator
 
-**Why:** npm is used ONLY for the ReScript compiler (which requires it). All other tooling uses Deno. Do not add npm dependencies.
+**Why:** Deno-only build (post panll#65). ReScript and Tailwind run via `npm:` specifiers in `deno.json` — there is no `package.json` and no npm CLI is invoked. Do not reintroduce npm/bun/yarn/pnpm tooling.
 
 ### [CRITICAL] anticrash-validates-all
 
@@ -150,11 +150,11 @@ These choices may look unusual but are intentional:
 
 **Rejected alternatives:** rescript-tea, Redux, MobX, React hooks pattern
 
-### deno-npm-hybrid
+### deno-only-with-npm-specifiers
 
-**Decision:** Deno orchestrates everything, but npm is used solely for the ReScript compiler
+**Decision:** Deno orchestrates everything; ReScript and Tailwind run via `npm:` specifiers in `deno.json`
 
-**Why:** ReScript compiler requires npm — this is the ONLY permitted npm usage. Do not extend npm's role.
+**Why:** Post panll#65: `package.json` + `package-lock.json` deleted; ReScript compiles via `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0 build`, Tailwind via `deno run -A npm:tailwindcss`. No npm CLI invocation. Do not extend npm's role.
 
 ### binary-star
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (2026-05-30 — npm → Deno migration)
+- **`package.json` + `package-lock.json` deleted.** ReScript and Tailwind now
+  run via `npm:` specifiers in `deno.json`:
+  - ReScript: `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0 build`
+    (exposed as `deno task res:build`)
+  - Tailwind: `deno run -A npm:tailwindcss` (transitional — no Deno-native
+    drop-in yet)
+- **`setup-node` removed from CI** in `.github/workflows/build-validation.yml`
+  and `.github/workflows/e2e.yml`; supersedes the `panll#62` `npm install`
+  band-aid. See `panll#65` for the migration PR.
+
 ### Changed (2026-05-17 — Tech-debt remediation: lib/bin split)
 - **`[lib] panll` crate extracted** — all GTK-free backend logic
   (`http_client`, `service_registry`, `settings`, `identity`, `groove`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ container support and tighter integration with the hyperpolymath stack.
 
 **Deno instead of npm/Node** — No `node_modules` directory (1,200+ transitive
 deps for a typical Node project). Built-in test runner. Secure-by-default
-permissions. npm is only used for the ReScript compiler itself.
+permissions. ReScript and Tailwind run via `npm:` specifiers in `deno.json`;
+there is no `package.json` and no npm CLI is invoked.
 
 **Elixir/BEAM for middleware** — BEAM's supervision trees mean a crashing backend
 connection restarts itself without taking down the whole panel surface. Pattern

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -70,7 +70,7 @@ or contradict deliberate architectural decisions.
 
 **Rule:** No npm, Bun, pnpm, or yarn — Deno is the orchestrator
 
-**Why:** npm is used ONLY for the ReScript compiler (which requires it). All other tooling uses Deno. Do not add npm dependencies.
+**Why:** Deno-only build (post panll#65). ReScript and Tailwind run via `npm:` specifiers in `deno.json` — there is no `package.json` and no npm CLI is invoked. Do not reintroduce npm/bun/yarn/pnpm tooling.
 
 ### [CRITICAL] anticrash-validates-all
 
@@ -150,11 +150,11 @@ These choices may look unusual but are intentional:
 
 **Rejected alternatives:** rescript-tea, Redux, MobX, React hooks pattern
 
-### deno-npm-hybrid
+### deno-only-with-npm-specifiers
 
-**Decision:** Deno orchestrates everything, but npm is used solely for the ReScript compiler
+**Decision:** Deno orchestrates everything; ReScript and Tailwind run via `npm:` specifiers in `deno.json`
 
-**Why:** ReScript compiler requires npm — this is the ONLY permitted npm usage. Do not extend npm's role.
+**Why:** Post panll#65: `package.json` + `package-lock.json` deleted; ReScript compiles via `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0 build`, Tailwind via `deno run -A npm:tailwindcss`. No npm CLI invocation. Do not extend npm's role.
 
 ### binary-star
 

--- a/README.adoc
+++ b/README.adoc
@@ -145,7 +145,7 @@ PanLL components aim to:
 
 |Runtime
 |Deno (tests, build orchestration)
-|No `node_modules` black hole — URL imports, built-in TypeScript support for glue code, secure-by-default permissions model. npm is only used for the ReScript compiler itself (pending upstream Deno support). See https://deno.com[Deno].
+|No `node_modules` black hole — URL imports, built-in TypeScript support for glue code, secure-by-default permissions model. Deno-only build: ReScript and Tailwind run through `npm:` specifiers in `deno.json`, no `package.json` or npm CLI invocation. See https://deno.com[Deno].
 
 |Testing
 |Deno.test (97 JS) + cargo test (12 Rust)
@@ -170,15 +170,15 @@ PanLL components aim to:
 
 == Development
 
-PanLL uses Deno for runtime, testing, and build orchestration. ReScript compilation uses the symlinked compiler in `node_modules`.
+PanLL uses Deno for runtime, testing, and build orchestration. ReScript compilation runs through `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0` (no `package.json` or npm CLI).
 
 [source,bash]
 ----
 # Compile ReScript modules
-npx rescript build
+deno task res:build
 
 # Watch ReScript sources during development
-npx rescript build -w
+deno task res:watch
 
 # Run tests (97 JS tests + 12 Rust tests)
 deno task test
@@ -201,7 +201,7 @@ deno task build
 [source,bash]
 ----
 # 1. Compile ReScript
-npx rescript build
+deno task res:build
 
 # 2. Run tests to verify
 deno task test

--- a/coordination.k9
+++ b/coordination.k9
@@ -71,7 +71,7 @@ invariants:
 
   - id: no-npm-bun
     rule: "No npm, Bun, pnpm, or yarn — Deno is the orchestrator"
-    reason: "npm is used ONLY for the ReScript compiler (which requires it). All other tooling uses Deno. Do not add npm dependencies."
+    reason: "Deno-only build (post panll#65). ReScript and Tailwind run via `npm:` specifiers in deno.json — there is no `package.json` and no npm CLI is invoked. Do not reintroduce npm/bun/yarn/pnpm tooling."
     severity: critical
 
   - id: anticrash-validates-all
@@ -154,9 +154,9 @@ architecture:
       - MobX
       - React hooks pattern
 
-  - id: deno-npm-hybrid
-    decision: "Deno orchestrates everything, but npm is used solely for the ReScript compiler"
-    reason: "ReScript compiler requires npm — this is the ONLY permitted npm usage. Do not extend npm's role."
+  - id: deno-only-with-npm-specifiers
+    decision: "Deno orchestrates everything; ReScript and Tailwind run via `npm:` specifiers in deno.json"
+    reason: "Post panll#65: package.json + package-lock.json deleted; ReScript compiles via `deno run -A --allow-scripts=npm:rescript npm:rescript@^12.0.0 build`, Tailwind via `deno run -A npm:tailwindcss`. No npm CLI invocation. Do not extend npm's role."
 
   - id: binary-star
     decision: "Three panel types: Panel-L (symbolic/human), Panel-N (neural/machine), Panel-W (world/shared)"

--- a/docs/archive/NPM-TO-DENO-MIGRATION.md
+++ b/docs/archive/NPM-TO-DENO-MIGRATION.md
@@ -1,6 +1,13 @@
 # npm → Deno Migration Plan for PanLL
 
-**Status:** Planning phase
+> **STATUS: CLOSED (2026-05-30).** Closed by panll#65 — `package.json` and
+> `package-lock.json` deleted; ReScript + Tailwind now run through `npm:`
+> specifiers in `deno.json`. See the `deno.json` task table and
+> `.github/workflows/build-validation.yml` for the shipped state. The text
+> below is preserved as the original planning document for historical context;
+> details may not reflect what actually shipped.
+
+**Status:** Planning phase (superseded)
 **Priority:** Medium (blocks full hyperpolymath policy compliance)
 **Timeline:** 1-2 weeks implementation
 **Blocker:** ReScript compiler requires Node.js/npm (no Deno support yet)

--- a/docs/guides/llm-warmup-user.md
+++ b/docs/guides/llm-warmup-user.md
@@ -68,7 +68,7 @@ Optional: Elixir >= 1.16 (for beam/ middleware).
 ## Rules
 
 - No TypeScript. ReScript only.
-- No npm/bun. Deno only (npm only for ReScript compiler).
+- No npm/bun. Deno only (ReScript + Tailwind run via `npm:` specifiers in `deno.json`).
 - Panels, not panes.
 - TEA pattern only. All state in Model.model.
 - Anti-Crash validates ALL neural tokens.

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -16,9 +16,10 @@ const ctx = await esbuild.context({
   format: "esm",
   outfile: "public/app.bundle.js",
   sourcemap: true,
-  // Tauri JS APIs are thin wrappers around window.__TAURI_INTERNALS__ IPC —
-  // bundling them is the standard approach and avoids bare-specifier issues
-  // in WebKitGTK which lacks import map support.
+  // Gossamer IPC bindings are thin wrappers around the WebKitGTK message
+  // handlers exposed by the Rust backend — bundling them is the standard
+  // approach and avoids bare-specifier issues in WebKitGTK which lacks
+  // import map support.
   nodePaths: ["node_modules"],
   logLevel: "info",
 });

--- a/src/model/README.md
+++ b/src/model/README.md
@@ -26,4 +26,4 @@ Contains all domain-specific type definitions for PanLL's TEA architecture. Each
 2. Add `include NewDomainModel` to `src/Model.res`
 3. Add any new fields to the `model` record in `Model.res`
 4. Add init values in the `init()` function in `Model.res`
-5. Run `npx rescript build` — compiler errors show every place needing updates
+5. Run `deno task res:build` — compiler errors show every place needing updates

--- a/tests/cross_panel_integration_test.js
+++ b/tests/cross_panel_integration_test.js
@@ -239,7 +239,7 @@ Deno.test("Integration — SeamEngine fullScan with realistic file list", () => 
     "src/core/AntiCrashEngine.res",
     "src/core/SeamEngine.res",
     "src/Model.res",
-    "package.json",
+    "deno.json",
     "rescript.json",
     "TOPOLOGY.md",
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- **Follows panll#65** (npm → Deno migration: `package.json` + `package-lock.json` deleted; ReScript + Tailwind now run via `npm:` specifiers in `deno.json` through `deno task res:build` / `deno run -A npm:tailwindcss`).
- Sweeps the doc surface for stale `npx rescript build` / "npm only for ReScript" / Tauri-where-Gossamer-is-meant prose.
- No file overlap with #65 — both PRs can auto-merge independently.
- Excludes `panll/.claude/CLAUDE.md` per owner directive (panll#60 reverted; excluded from sweeps).

## File-by-file rationale

| File | Change |
|------|--------|
| `README.adoc` | `npx rescript build` → `deno task res:build` (Development + Quick Start); Runtime cell reworded |
| `src/model/README.md` | `npx rescript build` → `deno task res:build` in "Adding a New Module" |
| `docs/guides/llm-warmup-user.md` | Rules line: "Deno only (ReScript + Tailwind via `npm:` specifiers in `deno.json`)" |
| `AGENTS.md` / `GEMINI.md` / `.junie/guidelines.md` | `no-npm-bun` rule + decision block (renamed `deno-only-with-npm-specifiers`) reworded to shipped reality |
| `coordination.k9` | Source-of-truth update for the three K9-generated docs above (prevents drift on regeneration) |
| `CONTRIBUTING.md` | "Deno instead of npm/Node" paragraph reworded |
| `CHANGELOG.md` | New `Unreleased` entry for 2026-05-30 documenting panll#65 |
| `scripts/bundle.ts` | Comment at line 19: Tauri JS APIs → Gossamer IPC bindings |
| `docs/archive/NPM-TO-DENO-MIGRATION.md` | Added "CLOSED 2026-05-30 by panll#65" status banner; body preserved |
| `tests/cross_panel_integration_test.js` | SeamEngine fixture file list: `"package.json"` → `"deno.json"` (post-#65 layout) |

## Out-of-scope (untouched)

- `panll/.claude/CLAUDE.md` — owner directive
- `.github/workflows/build-validation.yml` + `e2e.yml` — panll#65 territory
- All `.res` / `.resi` files — standards#252 scope
- `TOPOLOGY.md` — already clean (`deno task res:build`; remaining Tauri references are historical-migration context)
- 2 estate-adjacent docs with stale `npx`/`npm install` lines (`docs/developer-guide.md`, `docs/guides/QUICKSTART-FOR-SON.md`) — flagged in the meander, not in this PR's scope

## Test plan

- [ ] CI build-validation passes (no `.res` files changed, so ReScript build is unaffected)
- [ ] e2e workflow passes
- [ ] `deno task test` passes locally with the updated `tests/cross_panel_integration_test.js` fixture
- [ ] Verify no `.claude/CLAUDE.md` edits in the diff
- [ ] Verify auto-merge can proceed independent of #65

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>