### PR TITLE
docs: drop stale `npm install -g rescript` + `npx rescript-legacy -w` refs

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -91,10 +91,9 @@ source $HOME/.cargo/env
 curl -fsSL https://deno.land/x/install/install.sh | sh
 export DENO_INSTALL="/home/$USER/.deno"
 export PATH="$DENO_INSTALL/bin:$PATH"
-
-# Install ReScript
-npm install -g rescript
 ```
+
+ReScript is pinned in `deno.json` (`npm:rescript@^12.0.0`) and resolved on first `deno task res:build` — no global install required.
 
 ### Clone and Build
 

--- a/docs/guides/QUICKSTART-FOR-SON.md
+++ b/docs/guides/QUICKSTART-FOR-SON.md
@@ -16,7 +16,7 @@ On top of these, there are **overlay panels** you can open from the panel bar (v
 cd ~/Documents/hyperpolymath-repos/panll
 
 # Terminal 1: Start the ReScript compiler (watches for changes)
-npx rescript-legacy -w
+deno task res:watch
 
 # Terminal 2: Bundle the JS and serve
 just bundle && just serve:dev


### PR DESCRIPTION
## Summary

Two-line doc fix surfaced by the panll#66 meander. Follows panll#65 (npm→Deno migration) and panll#66 (docs sweep).

- `docs/developer-guide.md` — drop the `npm install -g rescript` step from the install block; ReScript is now resolved via `deno.json` (`npm:rescript@^12.0.0`) on first `deno task res:build` — no global install required. Surrounding prose reworded to reflect this.
- `docs/guides/QUICKSTART-FOR-SON.md` — `npx rescript-legacy -w` → `deno task res:watch` (matches the watch task added in panll#65).

## Test plan

- [ ] CI green (docs-only diff; no build impact)
- [ ] Markdown structure of `developer-guide.md` still renders correctly through the rewritten section (Install Deno block closes, prose paragraph, then `### Clone and Build` heading)
- [ ] `QUICKSTART-FOR-SON.md` watch-mode command matches the `res:watch` task in `deno.json` (added by panll#65)

## Related

- panll#65 — npm→Deno migration (introduces `deno task res:build` / `res:watch`)
- panll#66 — post-#65 doc-sweep (broader Tauri/npx text cleanup)
- standards#253 — estate npm→Deno umbrella

## Not in scope

- `QUICKSTART-FOR-SON.md` still references the Tauri backend on lines 27–28, 37 — separate PR
- AGENTS/GEMINI/.junie regeneration script `generate.js` is referenced in headers but missing from repo — separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)