### PR TITLE
docs: drop stale Tauri refs in QUICKSTART-FOR-SON + canonicalise panic-attacker→panic-attack

### DIFF
--- a/QUICKSTART-DEV.adoc
+++ b/QUICKSTART-DEV.adoc
@@ -31,7 +31,7 @@ just help-me   # see available commands
 
 [source,bash]
 ----
-just assail    # run panic-attacker security scan
+just assail    # run panic-attack security scan
 ----
 
 == Contributing

--- a/docs/guides/QUICKSTART-FOR-SON.md
+++ b/docs/guides/QUICKSTART-FOR-SON.md
@@ -24,8 +24,8 @@ just bundle && just serve:dev
 # Terminal 3: Build Tailwind CSS
 just css:build
 
-# Terminal 4: Start the Tauri backend
-cd src-tauri && cargo run
+# Terminal 4: Start the Gossamer backend
+cargo run --bin panll-gossamer
 ```
 
 Or for the full dev experience:
@@ -34,7 +34,7 @@ Or for the full dev experience:
 just dev
 ```
 
-The app opens at `http://localhost:8000/public/` (Tauri wraps this).
+The app opens at `http://localhost:8000/public/` (Gossamer wraps this).
 
 ## First Thing You See
 

--- a/docs/guides/llm-warmup-dev.md
+++ b/docs/guides/llm-warmup-dev.md
@@ -165,7 +165,7 @@ Files: TypeLLModel.res, TypeLLEngine.res, TypeLLCmd.res, TypeLLService.res, Type
 |---------|------|
 | ECHIDNA | Theorem prover dispatch |
 | VeriSimDB | 8-modality versioned database |
-| panic-attacker | Security analysis |
+| panic-attack | Security analysis |
 | BoJ server | Cartridge server, protocol gateway |
 | TypeLL | Type verification kernel |
 | contractiles | Elastic contract framework |
@@ -182,5 +182,5 @@ deno test --no-check --allow-read --allow-env tests/
 ## Pre-commit
 
 ```bash
-just assail    # panic-attacker scan
+just assail    # panic-attack scan
 ```

--- a/docs/guides/llm-warmup-user.md
+++ b/docs/guides/llm-warmup-user.md
@@ -75,5 +75,5 @@ Optional: Elixir >= 1.16 (for beam/ middleware).
 
 ## Related Projects
 
-ECHIDNA (prover), VeriSimDB (database), panic-attacker (security),
+ECHIDNA (prover), VeriSimDB (database), panic-attack (security),
 BoJ server (protocol gateway), TypeLL (type verification).


### PR DESCRIPTION
## Summary

Closes the remaining two items from the panll#66 adjacent-gap meander. Follows panll#65 / #66 / #67.

### QUICKSTART-FOR-SON.md — Gossamer migration cleanup

The Son's quickstart was still pointing at the old Tauri backend even though panll migrated to Gossamer (Zig + WebKitGTK) long ago. Two lines updated:

- Terminal 4 step `cd src-tauri && cargo run` → `cargo run --bin panll-gossamer`
- "(Tauri wraps this)" → "(Gossamer wraps this)"

### panic-attacker → panic-attack canonicalisation

Canonical estate name is `panic-attack` (matches the `hyperpolymath/panic-attack` repo and `.claude/CLAUDE.md` critical-rules section). Four references in live docs corrected:

- `QUICKSTART-DEV.adoc` — `just assail` comment
- `docs/guides/llm-warmup-dev.md` — Related-Projects table row + pre-commit comment
- `docs/guides/llm-warmup-user.md` — Related Projects prose

`AGENTS.md` / `GEMINI.md` / `.junie/guidelines.md` already use `panic-attack` correctly (no change).

### Out of scope

- `docs/status/PANLL-COMPLETE-STATUS-2026-02-11.md` is a historical audit snapshot dated 2026-02-11; left as-is.

## Test plan

- [ ] CI green (docs-only diff)
- [ ] `git grep panic-attacker -- '*.md' '*.adoc'` returns only the historical PANLL-COMPLETE-STATUS file
- [ ] `git grep "Tauri" docs/guides/QUICKSTART-FOR-SON.md` returns no results

## Related

- panll#65 — npm→Deno migration
- panll#66 — post-#65 doc sweep
- panll#67 — stale rescript install + watch refs
- panll#68 — K9 generate.js missing issue
- standards#253 — estate npm→Deno umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)