### PR TITLE
feat(migration/msg): port 3 self-contained msg types (megaport STEP 8 follow-up)

### DIFF
--- a/migration/msg/FeedbackMsg.affine
+++ b/migration/msg/FeedbackMsg.affine
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// FeedbackMsg.affine — Feedback-O-Tron messages (user feedback submission
+// lifecycle).
+//
+// Translation of src/msg/FeedbackMsg.res (11 LoC). Pure sum-type module
+// using `Result<String, String>` from prelude. No cross-module msg/model
+// dep.
+//
+// Refs: standards#279 (megaport STEP 8).
+
+module FeedbackMsg;
+
+use prelude::{Result, Ok, Err};
+
+type FeedbackMsg =
+  | OpenFeedback
+  | SubmitFeedback(String)
+  | CancelFeedback
+  | SetReportType(String)
+  | FeedbackSubmitted
+  | FeedbackSubmissionResult(Result<String, String>)

--- a/migration/msg/OrbitalMsg.affine
+++ b/migration/msg/OrbitalMsg.affine
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// OrbitalMsg.affine — orbital stability messages (stability, divergence,
+// drift aura).
+//
+// Translation of src/msg/OrbitalMsg.res (8 LoC). Pure sum-type module
+// — no cross-module deps, no Tea_/Promise/FFI surface. The cleanest
+// possible Mode-A port in panll's src/msg/ tree.
+//
+// Refs: standards#279 (megaport STEP 8).
+
+module OrbitalMsg;
+
+type OrbitalMsg =
+  | UpdateStability(Float)
+  | UpdateDivergence(Float)
+  | SetDriftAura(String)

--- a/migration/msg/VideoCoordinationMsg.affine
+++ b/migration/msg/VideoCoordinationMsg.affine
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// VideoCoordinationMsg.affine — messages for the VideoCoordination panel
+// (Drive-to-Photos batch transfers).
+//
+// Translation of src/msg/VideoCoordinationMsg.res (11 LoC). Pure sum-type
+// module using `Result<String, String>` from prelude.
+//
+// Refs: standards#279 (megaport STEP 8).
+
+module VideoCoordinationMsg;
+
+use prelude::{Result, Ok, Err};
+
+type VideoCoordinationMsg =
+  | StartTransfer(String, String)
+  | PauseTransfer(String)
+  | RefreshStatus
+  | StatusResult(Result<String, String>)
+  | TransferResult(Result<String, String>)
+  | ClearError


### PR DESCRIPTION
3 new .affine files (FeedbackMsg / OrbitalMsg / VideoCoordinationMsg) sitting on branch from 2026-05-31, never PR'd. Filed during 2026-06-02 estate orphan-branch sweep. Behind main by 5 commits — needs rebase if non-trivial conflict.