### PR TITLE
fix(ci): drop hardcoded version string from RSR-COMPLIANCE-REPORT.md

### DIFF
--- a/RSR-COMPLIANCE-REPORT.md
+++ b/RSR-COMPLIANCE-REPORT.md
@@ -5,7 +5,6 @@
 **Status**: ✅ FULLY COMPLIANT
 **Date**: 2026-04-07
 **System**: PanLL Wizard System
-**Version**: 1.0.0
 
 ## Compliance Matrix
 


### PR DESCRIPTION
Clears the pre-existing **Governance → "Security policy checks" [R5b]** failure (`pinned version-string in load-bearing docs`).

Removes the `**Version**: 1.0.0` line from `RSR-COMPLIANCE-REPORT.md`; version is deferred to `CHANGELOG.md` / `Cargo.toml` per the check's own guidance.

(Scoped narrowly: panll's other pre-existing reds — K9 magic-numbers across 103 `.k9.ncl`, the ReScript banned-language exemption, and the real code regressions `gossamer-rs`/panel-count/missing-exports — are tracked separately; see the session summary. The ReScript exemption specifically needs an estate-side `path_allow_prefixes` in hypatia, not an in-repo baseline, which would otherwise activate the skipped `validate-hypatia-baseline` job.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019awZjBD1qx61tvmEuEKNpn

---
_Generated by [Claude Code](https://claude.ai/code/session_019awZjBD1qx61tvmEuEKNpn)_