### PR TITLE
fix(ci): re-pin rust-ci-reusable past toolchain-input breakage

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   rust-ci:
-    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
+    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@412a7031577112b31ee287cc6060179d638d6500


### PR DESCRIPTION
Re-pins `rust-ci-reusable.yml` from `d135b05bfc647d0c0fbfedc7e80f37ea50f49236` (pre-fix) to `412a7031577112b31ee287cc6060179d638d6500` (standards main).

**Why:** the old SHA predates standards#439. Under a SHA-pinned `dtolnay/rust-toolchain`, the `toolchain` input is mandatory; without it all four rust-ci jobs (`check`/`test`/`audit`/`coverage`) fail immediately with `'toolchain' is a required input` — an estate-wide Rust CI breakage. This PR restores green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)