### PR TITLE
fix(ci): close the governance gate — SPDX, permissions, SHA pins, reusable bump

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -31,4 +31,4 @@ permissions:
 
 jobs:
   governance:
-    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
+    uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@81dbf2dd854b1444fd6236fa2352474383b2c2b9

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@81dbf2dd854b1444fd6236fa2352474383b2c2b9
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,5 +15,5 @@ jobs:
     permissions:
       security-events: write
       id-token: write
-    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@81dbf2dd854b1444fd6236fa2352474383b2c2b9
     secrets: inherit


### PR DESCRIPTION
The governance gate is all-jobs-must-pass, so these ship as one commit;
individually none of them turns the repo green.

* SPDX line-1 header and a top-level `permissions:` block on every
  workflow file (the two `Workflow security linter` checks).
* Every `uses:` tag reference resolved to a full 40-hex commit SHA. This
  satisfies the linter and also the repository's own
  `sha_pinning_required` Actions policy, which refuses `@v4` at parse
  time — a refusal that produces no check run at all.
* `hypatia-scan.yml` now grants `security-events: write`. This is not
  cosmetic and is not separable from the pin bump below: at HEAD the
  reusable declares `security-events: write` where the old pin declared
  `read`, and a called workflow cannot escalate beyond its caller's
  grant. Bumping the pin without this would fail at parse time.
* The three reusables watched by the staleness gate (governance,
  hypatia-scan, scorecard) advanced to standards HEAD, which is 62
  commits ahead of the false-green cache fix and includes the
  deny-list-negative fix from standards#524.

`mirror-reusable` and `secret-scanner-reusable` are deliberately left on
their current pins: the staleness gate does not watch them, so they are
not holding anything red, and bumping them carries unrelated risk.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

