### PR TITLE
chore(ci): make Scorecard periodic, not per-push

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,8 +5,6 @@ on:
   branch_protection_rule:
   schedule:
     - cron: '23 4 * * 1'
-  push:
-    branches: [main]
 
 permissions: read-all
 


### PR DESCRIPTION
Makes the OpenSSF Scorecard workflow **periodic** by dropping its `push` (and, in one repository, `pull_request`) trigger. `schedule`, `workflow_dispatch` and `branch_protection_rule` are all kept.

**Why.** Scorecard measures the *repository's* supply-chain posture, not the change under review. That is the `📅 PERIODIC:` tier in the estate's signal-discipline standard: on a schedule against the default branch, feeding a dashboard — not on every event. It cannot meaningfully pass or fail a diff.

**Measured across 303 scorecard workflows before this sweep:**

```
199  push, schedule, workflow_dispatch
 93  branch_protection_rule, schedule, push
  1  push, pull_request, schedule, workflow_dispatch
  1  schedule, workflow_dispatch          <- the target shape
```

So ~292 repositories ran a full posture scan on **every push to the default branch**. That is pure cost: the score cannot meaningfully change between two consecutive merges.

**Deliberately kept:** `branch_protection_rule`. It fires on a settings change — not per pull request — so it does not violate the PERIODIC rule, and it re-measures precisely what Scorecard scores after exactly the change most likely to alter it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
