### PR TITLE
docs(agents): TypeScript → AffineScript, not ReScript

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,7 +71,7 @@ deno task test:coverage
 ## Critical Rules
 
 - **NEVER use Tauri** — project migrated to Gossamer. All backend refs use `src-gossamer/`
-- **NEVER use TypeScript** — ReScript only
+- **NEVER use TypeScript** — AffineScript only (ReScript is also banned; RS/TS/JS → AffineScript → typed-wasm)
 - **NEVER use npm/bun** — Deno only (npm used only for ReScript compiler)
 - **Panels, not panes** — PanLL uses "panels" terminology
 - **TEA pattern only** — no MVC, no Redux, no hooks. Model -> Msg -> Update -> View


### PR DESCRIPTION
`.claude/CLAUDE.md:74` read:

> `- **NEVER use TypeScript** — ReScript only`

**ReScript is itself banned estate-wide** (`LANGUAGE-POLICY.adoc` §3), so this line directed agents at a banned language. Corrected per the owner ruling of 2026-08-25 (hyperpolymath/standards#632): AffineScript governs, and the migration path is RS/TS/JS → AffineScript → typed-wasm.

This file is what agents read first, so a wrong rule here propagates into every session.

Tracked by hyperpolymath/standards#281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)