### PR TITLE
fix(scripts): put the shebang on line 1 of panll-launcher.sh

### DIFF
--- a/panll-launcher.sh
+++ b/panll-launcher.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>


### PR DESCRIPTION
The shebang was **not the first line**, so the kernel never honoured it — the script ran under whatever shell invoked it rather than the one it declares. shellcheck reports this as `SC1128`.

Found by an estate-wide sweep of **5,111 tracked scripts across 375 repos**: 20 files carry this defect, 19 of them a generated `*-launcher.sh`.

⚠ **Source not identified.** The generator `standards/docs/UX-standards/comprehensive-launcher-template.sh` is **clean** — its own line 1 is the shebang and it reports 0 shellcheck errors. The stray line is introduced when the launcher is copied into each repo, by something not yet found, so **this may recur** until that is tracked down.

Other lines are preserved in order; only the shebang moves.