### PR TITLE
fix(ci): the invisible-character gate never matched anything

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -128,7 +128,7 @@ jobs:
           # Checks for: zero-width spaces, zero-width joiners, BOM, soft hyphens,
           # non-breaking spaces, null bytes, and other invisible Unicode in source files.
           set +e
-          PATTERNS='\xc2\xa0|\xe2\x80\x8b|\xe2\x80\x8c|\xe2\x80\x8d|\xef\xbb\xbf|\xc2\xad|\xe2\x80\x8e|\xe2\x80\x8f|\xe2\x80\xaa|\xe2\x80\xab|\xe2\x80\xac|\xe2\x80\xad|\xe2\x80\xae|\x00'
+          PATTERNS='\x00|[\x01-\x08\x0B\x0C\x0E-\x1F]|\x{a0}|\x{ad}|\x{200b}|\x{200c}|\x{200d}|\x{200e}|\x{200f}|\x{202a}|\x{202b}|\x{202c}|\x{202d}|\x{202e}|\x{2060}|\x{feff}'
           find "$GITHUB_WORKSPACE" \
             -not -path '*/.git/*' -not -path '*/node_modules/*' \
             -not -path '*/.deno/*' -not -path '*/target/*' \
@@ -139,7 +139,7 @@ jobs:
               -o -name '*.yml' -o -name '*.yaml' -o -name '*.md' -o -name '*.adoc' \
               -o -name '*.idr' -o -name '*.zig' -o -name '*.v' -o -name '*.jl' \
               -o -name '*.gleam' -o -name '*.hs' -o -name '*.ml' -o -name '*.sh' \) \
-            -exec grep -Prl "$PATTERNS" {} \; > /tmp/empty-lint-results.txt 2>/dev/null
+            -exec grep -aPrl "$PATTERNS" {} \; > /tmp/empty-lint-results.txt 2>/dev/null
           EL_EXIT=$?
           set -e
 


### PR DESCRIPTION
**Measured 2026-08-27: this gate caught 0 of 6 invisible-character test cases.** It has never detected an NBSP, zero-width space, BOM, soft hyphen, bidi override or word joiner.

## Root cause

The pattern used UTF-8 **byte sequences** (`\xc2\xa0`) while `grep -P` matches **characters**. Bytes `c2 a0` are *one* character U+00A0; `\xc2\xa0` asks for *two*, U+00C2 then U+00A0 — never present.

```
grep -P '\xc2\xa0'  ->  miss
grep -P '\x{a0}'    ->  MATCH
```

Only `\x00` worked, being single-byte in both readings. The gate ran, passed, and could not see what it exists to see.

## Fixed

- **codepoint escapes** in place of byte sequences
- **C0 controls** `\x01-\x08,\x0B,\x0C,\x0E-\x1F` added (TAB/LF/CR excluded)
- **`grep -a`** — without it grep skips any NUL-bearing file as binary

The C0 range matters: a stray **backspace byte** made a workflow unparseable in `developer-ecosystem`, so it never ran — and this linter called it clean.

Canonical fix: hyperpolymath/empty-linter#70. **1 file(s)** here.

**Verified:** YAML re-parsed, and the corrected pattern was confirmed to catch a real NBSP before the change was kept.